### PR TITLE
Replace ImageSharp with SkiaSharp

### DIFF
--- a/SigVerSdk/SigVerSdk.csproj
+++ b/SigVerSdk/SigVerSdk.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- switch ImageSharp dependency to SkiaSharp
- update `SigVerifier` implementation to use SkiaSharp

## Testing
- `python convert_to_onnx.py`

------
https://chatgpt.com/codex/tasks/task_e_688750ba888483259bd70872e275fa77