### PR TITLE
Update docs for dotnet-install usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,13 @@ Run `python convert_to_onnx.py` to export the provided PyTorch weights to
 
 There are currently no automated tests. After modifying the repository, ensure
 that the export script still runs without errors.
+
+## .NET SDK
+If the .NET SDK is not available on your machine, you can install it locally
+using the `dotnet-install.sh` script included in the repository:
+
+```bash
+./dotnet-install.sh --channel 8.0
+```
+This downloads a recent SDK to `~/.dotnet` which is then used by the C#
+projects.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ SigVer provides neural models and training scripts for verifying handwritten sig
    python convert_to_onnx.py
    ```
    The script produces `models/signet.onnx` and `models/signet_f_lambda_0.95.onnx`.
+3. Install the .NET SDK (required to build `SigVerSdk`) if it is not already
+   available:
+   ```bash
+   ./dotnet-install.sh --channel 8.0
+   ```
 
 ## Using PyTorch models
 
@@ -43,6 +48,12 @@ float[] features = verifier.ExtractFeatures("data/a1.png");
 ```
 
 The unit tests in `SigVerSdk.Tests` illustrate a simple verification scenario comparing two signatures.
+
+If the required SDK is missing, run the provided install script before building:
+
+```bash
+./dotnet-install.sh --channel 8.0
+```
 
 ## Data preprocessing
 


### PR DESCRIPTION
## Summary
- document how to use `dotnet-install.sh` in AGENTS instructions
- add .NET SDK installation step in README quick install
- mention install script in the README .NET section

## Testing
- `python convert_to_onnx.py`

------
https://chatgpt.com/codex/tasks/task_e_6887563180ec83258367c1bfc46fa895